### PR TITLE
Only the enter key stops the server.

### DIFF
--- a/EchoTool/Modes/TcpServerMode.cs
+++ b/EchoTool/Modes/TcpServerMode.cs
@@ -82,7 +82,7 @@ namespace EchoTool.Modes
             Console.WriteLine(string.Format(Messages.TCPServerCaption, serverPort));
 
             echoServer.Start();            
-            Console.ReadLine();
+            Console.ReadKey(true);
             echoServer.Stop();
         }
 

--- a/EchoTool/Modes/UdpServerMode.cs
+++ b/EchoTool/Modes/UdpServerMode.cs
@@ -71,7 +71,7 @@ namespace EchoTool.Modes
             Console.WriteLine(string.Format(Messages.UDPServerCaption, serverPort));
 
             echoServer.Start();
-            Console.ReadLine();
+            Console.ReadKey(true);
             echoServer.Stop();
         }
 


### PR DESCRIPTION
Currently, only the enter key stops the server, but the application tells the user to "press any key to exit." I've added 'Console.ReadKey(true)' instead of the current 'Console.ReadLine()' so that a key press will stop the server.
