### PR TITLE
Fix Logging of Roundtrip Time

### DIFF
--- a/EchoTool/Modes/TcpClientMode.cs
+++ b/EchoTool/Modes/TcpClientMode.cs
@@ -171,7 +171,7 @@ namespace EchoTool.Modes
                 _echoCorrupted++;
             }
 
-            Console.WriteLine(Messages.ClientResponse, responseIpEndPoint, echoTime.Milliseconds, state);
+            Console.WriteLine(Messages.ClientResponse, responseIpEndPoint, echoTime.TotalMilliseconds, state);
 
             _echoReceived++;
         }

--- a/EchoTool/Modes/UdpClientMode.cs
+++ b/EchoTool/Modes/UdpClientMode.cs
@@ -168,7 +168,7 @@ namespace EchoTool.Modes
                 _echoCorrupted++;
             }
 
-            Console.WriteLine(Messages.ClientResponse, responseIpEndPoint, echoTime.Milliseconds, state);
+            Console.WriteLine(Messages.ClientResponse, responseIpEndPoint, echoTime.TotalMilliseconds, state);
 
             _echoReceived++;
         }

--- a/EchoTool/Resources/Messages.resx
+++ b/EchoTool/Resources/Messages.resx
@@ -121,7 +121,7 @@
     <value>Port already in use</value>
   </data>
   <data name="ClientResponse" xml:space="preserve">
-    <value>Reply from {0}, time {1} ms {2}</value>
+    <value>Reply from {0}, time {1:0} ms {2}</value>
   </data>
   <data name="UDPClientStatistics" xml:space="preserve">
     <value>Statistics: Received={0}, Corupted={1}, Lost={2}</value>


### PR DESCRIPTION
There was a small bug in the code that logs the round trip time.  The code was mistakenly using the `TimeSpan.Milliseconds` property instead of the `TimeSpan.TotalMilliseconds` property.  The impact was that any round trip greater than 1 second was only showing the milliseconds portion of the time span, instead of the entire time span expressed as milliseconds.